### PR TITLE
make Int64 aka JavaLong conform to JavaParameterConvertible

### DIFF
--- a/Sources/JNI/JNIFields.swift
+++ b/Sources/JNI/JNIFields.swift
@@ -49,7 +49,7 @@ public extension JNI {
         return result
     }
 
-    public func GetInt64Field(of javaObject: JavaObject, id: JavaFieldID) throws -> JavaLong {
+    public func GetLongField(of javaObject: JavaObject, id: JavaFieldID) throws -> JavaLong {
         let _env = self._env
         let result = _env.pointee.pointee.GetLongField(_env, javaObject, id)
         try checkAndThrowOnJNIError()
@@ -93,7 +93,7 @@ public extension JNI {
         return result
     }
 
-    public func GetStaticInt64Field(of javaClass: JavaClass, id: JavaFieldID) throws -> JavaLong {
+    public func GetStaticLongField(of javaClass: JavaClass, id: JavaFieldID) throws -> JavaLong {
         let _env = self._env
         let result = _env.pointee.pointee.GetStaticLongField(_env, javaClass, id)
         try checkAndThrowOnJNIError()

--- a/Sources/JNI/JNIFields.swift
+++ b/Sources/JNI/JNIFields.swift
@@ -49,6 +49,13 @@ public extension JNI {
         return result
     }
 
+    public func GetInt64Field(of javaObject: JavaObject, id: JavaFieldID) throws -> JavaLong {
+        let _env = self._env
+        let result = _env.pointee.pointee.GetLongField(_env, javaObject, id)
+        try checkAndThrowOnJNIError()
+        return result
+    }
+
     public func GetDoubleField(of javaObject: JavaObject, id: JavaFieldID) throws -> JavaDouble {
         let _env = self._env
         let result = _env.pointee.pointee.GetDoubleField(_env, javaObject, id)
@@ -82,6 +89,13 @@ public extension JNI {
     public func GetStaticFloatField(of javaClass: JavaClass, id: JavaFieldID) throws -> JavaFloat {
         let _env = self._env
         let result = _env.pointee.pointee.GetStaticFloatField(_env, javaClass, id)
+        try checkAndThrowOnJNIError()
+        return result
+    }
+
+    public func GetStaticInt64Field(of javaClass: JavaClass, id: JavaFieldID) throws -> JavaLong {
+        let _env = self._env
+        let result = _env.pointee.pointee.GetStaticLongField(_env, javaClass, id)
         try checkAndThrowOnJNIError()
         return result
     }

--- a/Sources/JNI/JNIMethods.swift
+++ b/Sources/JNI/JNIMethods.swift
@@ -123,6 +123,14 @@ extension JNI {
         return result
     }
 
+    public func CallInt64Method(_ method: JavaMethodID, on object: JavaObject, parameters: [JavaParameter]) throws -> JavaLong {
+        let _env = self._env
+        var methodArgs = parameters
+        let result = _env.pointee.pointee.CallLongMethod(_env, object, method, &methodArgs)
+        try checkAndThrowOnJNIError()
+        return result
+    }
+
     public func CallDoubleMethod(_ method: JavaMethodID, on object: JavaObject, parameters: [JavaParameter]) throws -> JavaDouble {
         let _env = self._env
         var methodArgs = parameters
@@ -164,6 +172,14 @@ extension JNI {
         let _env = self._env
         var methodArgs = parameters
         let result = _env.pointee.pointee.CallStaticIntMethodA(_env, javaClass, method, &methodArgs)
+        try checkAndThrowOnJNIError()
+        return result
+    }
+
+    public func CallStaticInt64Method(_ method: JavaMethodID, on javaClass: JavaClass, parameters: [JavaParameter]) throws -> JavaLong {
+        let _env = self._env
+        var methodArgs = parameters
+        let result = _env.pointee.pointee.CallStaticLongMethodA(_env, javaClass, method, &methodArgs)
         try checkAndThrowOnJNIError()
         return result
     }

--- a/Sources/JNI/JNIMethods.swift
+++ b/Sources/JNI/JNIMethods.swift
@@ -123,7 +123,7 @@ extension JNI {
         return result
     }
 
-    public func CallInt64Method(_ method: JavaMethodID, on object: JavaObject, parameters: [JavaParameter]) throws -> JavaLong {
+    public func CallLongMethod(_ method: JavaMethodID, on object: JavaObject, parameters: [JavaParameter]) throws -> JavaLong {
         let _env = self._env
         var methodArgs = parameters
         let result = _env.pointee.pointee.CallLongMethod(_env, object, method, &methodArgs)
@@ -176,7 +176,7 @@ extension JNI {
         return result
     }
 
-    public func CallStaticInt64Method(_ method: JavaMethodID, on javaClass: JavaClass, parameters: [JavaParameter]) throws -> JavaLong {
+    public func CallStaticLongMethod(_ method: JavaMethodID, on javaClass: JavaClass, parameters: [JavaParameter]) throws -> JavaLong {
         let _env = self._env
         var methodArgs = parameters
         let result = _env.pointee.pointee.CallStaticLongMethodA(_env, javaClass, method, &methodArgs)

--- a/Sources/JNI/JavaParameterConvertible+Primitives.swift
+++ b/Sources/JNI/JavaParameterConvertible+Primitives.swift
@@ -107,3 +107,29 @@ extension Float: JavaParameterConvertible, JavaInitializableFromMethod, JavaInit
         return try jni.GetFloatField(of: javaObject, id: fieldID)
     }
 }
+
+// Int64 aka JavaLong
+
+extension Int64: JavaParameterConvertible, JavaInitializableFromMethod, JavaInitializableFromField {
+    public static let asJNIParameterString = "J"
+
+    public func toJavaParameter() -> JavaParameter {
+        return JavaParameter(long: Int64(self))
+    }
+
+    public static func fromStaticField(_ fieldID: JavaFieldID, of javaClass: JavaClass) throws -> Int64 {
+        return try Int64(jni.GetStaticInt64Field(of: javaClass, id: fieldID))
+    }
+
+    public static func fromMethod(calling methodID: JavaMethodID, on object: JavaObject, args: [JavaParameter]) throws -> Int64 {
+        return try jni.CallInt64Method(methodID, on: object, parameters: args)
+    }
+
+    public static func fromStaticMethod(calling methodID: JavaMethodID, on javaClass: JavaClass, args: [JavaParameter]) throws -> Int64 {
+        return try jni.CallStaticInt64Method(methodID, on: javaClass, parameters: args)
+    }
+
+    public static func fromField(_ fieldID: JavaFieldID, on javaObject: JavaObject) throws -> Int64 {
+        return try jni.GetInt64Field(of: javaObject, id: fieldID)
+    }
+}

--- a/Sources/JNI/JavaParameterConvertible+Primitives.swift
+++ b/Sources/JNI/JavaParameterConvertible+Primitives.swift
@@ -108,28 +108,28 @@ extension Float: JavaParameterConvertible, JavaInitializableFromMethod, JavaInit
     }
 }
 
-// Int64 aka JavaLong
+// JavaLong aka Int64
 
-extension Int64: JavaParameterConvertible, JavaInitializableFromMethod, JavaInitializableFromField {
+extension JavaLong: JavaParameterConvertible, JavaInitializableFromMethod, JavaInitializableFromField {
     public static let asJNIParameterString = "J"
 
     public func toJavaParameter() -> JavaParameter {
-        return JavaParameter(long: Int64(self))
+        return JavaParameter(long: self)
     }
 
-    public static func fromStaticField(_ fieldID: JavaFieldID, of javaClass: JavaClass) throws -> Int64 {
-        return try Int64(jni.GetStaticInt64Field(of: javaClass, id: fieldID))
+    public static func fromStaticField(_ fieldID: JavaFieldID, of javaClass: JavaClass) throws -> JavaLong {
+        return try JavaLong(jni.GetStaticLongField(of: javaClass, id: fieldID))
     }
 
-    public static func fromMethod(calling methodID: JavaMethodID, on object: JavaObject, args: [JavaParameter]) throws -> Int64 {
-        return try jni.CallInt64Method(methodID, on: object, parameters: args)
+    public static func fromMethod(calling methodID: JavaMethodID, on object: JavaObject, args: [JavaParameter]) throws -> JavaLong {
+        return try jni.CallLongMethod(methodID, on: object, parameters: args)
     }
 
-    public static func fromStaticMethod(calling methodID: JavaMethodID, on javaClass: JavaClass, args: [JavaParameter]) throws -> Int64 {
-        return try jni.CallStaticInt64Method(methodID, on: javaClass, parameters: args)
+    public static func fromStaticMethod(calling methodID: JavaMethodID, on javaClass: JavaClass, args: [JavaParameter]) throws -> JavaLong {
+        return try jni.CallStaticLongMethod(methodID, on: javaClass, parameters: args)
     }
 
-    public static func fromField(_ fieldID: JavaFieldID, on javaObject: JavaObject) throws -> Int64 {
-        return try jni.GetInt64Field(of: javaObject, id: fieldID)
+    public static func fromField(_ fieldID: JavaFieldID, on javaObject: JavaObject) throws -> JavaLong {
+        return try jni.GetLongField(of: javaObject, id: fieldID)
     }
 }


### PR DESCRIPTION
This adds the ability to pass `Int64/JavaLongs` between worlds.
I'm not quite sure if the naming of the functions is correct. Do we want to `getInt64Fields` or do we want to `getLongFields`?