### PR TITLE
prevent fatal error when `CallObjectMethod` returns nil

### DIFF
--- a/Sources/JNI/JNIMethods.swift
+++ b/Sources/JNI/JNIMethods.swift
@@ -142,9 +142,9 @@ extension JNI {
     public func CallObjectMethod(_ method: JavaMethodID, on object: JavaObject, parameters: [JavaParameter]) throws -> JavaObject {
         let _env = self._env
         var methodArgs = parameters
-        let result = _env.pointee.pointee.CallObjectMethod(_env, object, method, &methodArgs)!
+        let result = _env.pointee.pointee.CallObjectMethod(_env, object, method, &methodArgs)
         try checkAndThrowOnJNIError()
-        return result
+        return result!
     }
 }
 


### PR DESCRIPTION
let `checkAndThrowOnJNIError` throw an error instead of crashing the entire app when force unwrapping nil