### PR TITLE
implement JNIObject.getField()

### DIFF
--- a/Sources/JNI/Array+JavaParameterConvertible.swift
+++ b/Sources/JNI/Array+JavaParameterConvertible.swift
@@ -15,7 +15,7 @@ extension String {
 }
 
 extension Array where Element == JavaParameterConvertible {
-    func asJavaParameters() -> [JavaParameter] {
+    public func asJavaParameters() -> [JavaParameter] {
         return self.map { $0.toJavaParameter() }
     }
 
@@ -27,12 +27,12 @@ extension Array where Element == JavaParameterConvertible {
 
     /// Returns the String of ordered arguments enclosed in brackets, followed by the `returnType`'s type string, or 'V'
     /// (Void) if nil is provided. e.g. Returns "(II)V" for `[JavaInt(1), JavaInt(99)].methodSignature(returnType: nil)`
-    func methodSignature(returnType: JavaParameterConvertible.Type?) -> String {
+    public func methodSignature(returnType: JavaParameterConvertible.Type?) -> String {
         let returnTypeString = returnType?.asJNIParameterString ?? "V"
         return "(" + self.argumentSignature() + ")" + returnTypeString
     }
 
-    func methodSignature(customReturnType: String) -> String {
+    public func methodSignature(customReturnType: String) -> String {
         let returnTypeString = customReturnType.replacingFullstopsWithSlashes()
         return "(" + self.argumentSignature() + ")" + returnTypeString
     }

--- a/Sources/JNI/JNIFields.swift
+++ b/Sources/JNI/JNIFields.swift
@@ -18,6 +18,9 @@ public extension JNI {
     func GetField<T: JavaInitializableFromField & JavaParameterConvertible>(_ fieldName: String, from javaObject: JavaObject) throws -> T {
         let env = self._env
         let javaClass = try GetObjectClass(obj: javaObject)
+        defer {
+            jni.DeleteLocalRef(javaClass)
+        }
         let fieldID = env.pointee.pointee.GetFieldID(env, javaClass, fieldName, T.asJNIParameterString)
         try checkAndThrowOnJNIError()
         return try T.fromField(fieldID!, on: javaObject)

--- a/Sources/JNI/JNIObjects.swift
+++ b/Sources/JNI/JNIObjects.swift
@@ -1,5 +1,6 @@
 import CJNI
 import Dispatch
+import Foundation
 
 /// Designed to simplify calling a constructor and methods on a JavaClass
 /// Subclass this and add the methods appropriate to the object you are constructing.
@@ -11,7 +12,7 @@ open class JNIObject {
     private static var classInstances = [String: JavaClass]()
 
     public static var javaClass: JavaClass {
-        return DispatchQueue.main.sync {
+        func getClassInstance() -> JavaClass {
             if let classInstance = classInstances[className] {
                 return classInstance
             }
@@ -23,6 +24,15 @@ open class JNIObject {
 
             return classInstance
         }
+
+        if Thread.isMainThread {
+            return getClassInstance()
+        } else {
+            return DispatchQueue.main.sync {
+                return getClassInstance()
+            }
+        }
+
     }
 
     public let instance: JavaObject

--- a/Sources/JNI/JNIObjects.swift
+++ b/Sources/JNI/JNIObjects.swift
@@ -71,6 +71,12 @@ open class JNIObject {
         return try jni.call(methodName, on: self.instance, arguments: arguments)
     }
 
+    public func getField<T: JavaInitializableFromField & JavaParameterConvertible>(
+        _ fieldName: String
+    ) throws -> T {
+        return try jni.GetField(fieldName, from: self.instance)
+    }
+
     public static func callStatic(methodName: String, arguments: [JavaParameterConvertible] = []) throws {
         try jni.callStatic(methodName, on: self.javaClass, arguments: arguments)
     }


### PR DESCRIPTION
Add a wrapper method on `JNIObject` around `jni.GetField` for convenience.